### PR TITLE
[#9] revert runner and update Java

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,17 +9,18 @@
 name: Build aiSSEMBLE Parent
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "dev" ]
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: maven
       - name: Build aissemble-parent

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,10 +23,10 @@ jobs:
         steps:
             - name: Check out code
               uses: actions/checkout@v4
-            - name: Set up JDK 11
+            - name: Set up JDK 17
               uses: actions/setup-java@v4
               with:
-                  java-version: '11'
+                  java-version: '17'
                   distribution: 'temurin'
                   cache: maven
                   server-id: 'ossrh'


### PR DESCRIPTION
Primarily this is to fix the build action never being picked up for execution. But I also noticed that we were installing Java 11 during the build and release actions, though 601cc17 just bumped the required Java version to 17.